### PR TITLE
Add share with WhatsApp button in ActivityDetailsDrawer.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8005,9 +8005,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
-      "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
+      "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/ActivityDetailsDrawer.tsx
+++ b/src/components/ActivityDetailsDrawer.tsx
@@ -1,4 +1,4 @@
-import { IconCalendarPlus, IconClock, IconCoinEuro, IconShare, IconTags, IconTemperatureSun, IconTool, IconUser, IconUsersGroup } from '@tabler/icons-react';
+import { IconCalendarPlus, IconClock, IconCoinEuro, IconTags, IconTemperatureSun, IconTool, IconUser, IconUsersGroup, IconBrandWhatsapp} from '@tabler/icons-react';
 import type { Activity } from '../types/activity';
 import { ActionIcon, Badge, Button, Divider, Drawer, Grid, Group, Text } from '@mantine/core';
 import React from 'react';
@@ -122,18 +122,23 @@ export default function ActivityDetailsDrawer(props: { data: Activity|null, open
 			>
 				Zum Kalender hinzufügen
 			</Button>
+
 			<Button
 				fullWidth
-				color="blue"
-				leftSection={<IconShare />}
 				mt="sm"
-				variant="light"
+				color="green"
+				leftSection={<IconBrandWhatsapp />}
 				onClick={() => {
-					// Implement share functionality here
+					const message = `${data.name}\n${data.description}\n${window.location.href}`;
+					window.open(
+					`https://wa.me/?text=${encodeURIComponent(message)}`,
+					'_blank',
+					'noopener,noreferrer'
+					);
 				}}
 			>
-				Teilen
+				Über WhatsApp teilen
 			</Button>
-		</Drawer>
-	)
+    	</Drawer>
+  	);
 }

--- a/src/components/ActivityDetailsDrawer.tsx
+++ b/src/components/ActivityDetailsDrawer.tsx
@@ -75,7 +75,24 @@ export default function ActivityDetailsDrawer(props: { data: Activity|null, open
 					</>,
 				},
 			];
+		const formatDate = (date: Date) => date.toISOString().replace(/-|:|\.\d+/g, '').slice(0, 15);
 
+		const handleAddToCalendar = () => {
+		const start = new Date();
+		const end = new Date(start.getTime() + 60 * 60 * 1000); // +1 hour
+
+		const shareTitle = data.name;
+		const shareDescription = data.description;
+		const shareUrl = window.location.href; // optional, if you want to include current page URL
+
+		const calendarUrl = `https://www.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
+			shareTitle
+		)}&details=${encodeURIComponent(shareDescription + "\n" + shareUrl)}&dates=${formatDate(
+			start
+		)}/${formatDate(end)}`;
+
+		window.open(calendarUrl, "_blank");
+		};
 
 	return (
 		<Drawer
@@ -117,7 +134,7 @@ export default function ActivityDetailsDrawer(props: { data: Activity|null, open
 				color="blue"
 				leftSection={<IconCalendarPlus />}
 				onClick={() => {
-					// Implement add to calendar functionality here
+					handleAddToCalendar()
 				}}
 			>
 				Zum Kalender hinzufügen


### PR DESCRIPTION
Updates:

I extended the share button with a function enabling users to share the activities via WhatsApp.

Clicking the button opens WhatsApp Web with a pre-filled message including:

- Activity name
- Activity description
- Current page URL (window.location.href)

In order to test the functionality, please log in WhatsApp Web first, then trigger the button.

I tested my changes on Brave and Safari.

This PR closes the related issue:  #37  
